### PR TITLE
feat: define scoring interfaces and models

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,32 +4,33 @@ version: 2.1
 setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@4.3.0
+    gravitee: gravitee-io/gravitee@4.4.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
 workflows:
-  setup_build:
-    when:
-      not: << pipeline.git.tag >>
-    jobs:
-      - gravitee/setup_lib-build-config:
-          filters:
-            tags:
-              ignore:
-                - /.*/
+    setup_build:
+        when:
+            not: << pipeline.git.tag >>
+        jobs:
+            - gravitee/setup_lib-build-config:
+                  githubReleasedAssets: "target/scoring-openapi.yaml|Scoring OpenAPI Specification"
+                  filters:
+                      tags:
+                          ignore:
+                              - /.*/
 
-  setup_release:
-    when:
-      matches:
-        pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
-        value: << pipeline.git.tag >>
-    jobs:
-      - gravitee/setup_lib-release-config:
-          filters:
-            branches:
-              ignore:
-                - /.*/
-            tags:
-              only:
-                - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/
+    setup_release:
+        when:
+            matches:
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
+                value: << pipeline.git.tag >>
+        jobs:
+            - gravitee/setup_lib-release-config:
+                  filters:
+                      branches:
+                          ignore:
+                              - /.*/
+                      tags:
+                          only:
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee</groupId>
+        <artifactId>gravitee-parent</artifactId>
+        <version>22.0.14</version>
+    </parent>
+
+    <groupId>io.gravitee.scoring</groupId>
+    <artifactId>gravitee-scoring-api</artifactId>
+    <version>0.0.0</version>
+    <name>Gravitee.io Scoring - API</name>
+
+    <properties>
+        <gravitee-bom.version>8.1.0</gravitee-bom.version>
+
+        <jakarata-ws.version>3.0.0</jakarata-ws.version>
+        <swagger.version>2.2.22</swagger.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-jaxrs2-jakarta</artifactId>
+            <version>${swagger.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
+            <version>${swagger.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${jakarata-ws.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>com.hubspot.maven.plugins</groupId>
+                <artifactId>prettier-maven-plugin</artifactId>
+                <configuration>
+                    <inputGlobs>
+                        <inputGlob>src/{main,test}/java/**/*.java</inputGlob>
+                        <inputGlob>{.circleci,.github,src}/**/*.{json,yaml,yml}</inputGlob>
+                    </inputGlobs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-maven-plugin-jakarta</artifactId>
+                <version>${swagger.version}</version>
+                <configuration>
+                    <outputPath>${basedir}/target</outputPath>
+                    <configurationFilePath>${basedir}/target/classes/openapi-configuration.yaml</configurationFilePath>
+                    <outputFileName>scoring-openapi</outputFileName>
+                    <outputFormat>JSONANDYAML</outputFormat>
+                    <prettyPrint>true</prettyPrint>
+                    <resourceClasses>io.gravitee.scoring.api.ScoreAssets</resourceClasses>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>resolve</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/io/gravitee/scoring/api/ScoreAssets.java
+++ b/src/main/java/io/gravitee/scoring/api/ScoreAssets.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api;
+
+import io.gravitee.scoring.api.model.ScoringRequest;
+import io.gravitee.scoring.api.model.ScoringResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/score-assets")
+public interface ScoreAssets {
+    @POST
+    @Operation(
+        summary = "Score a list of Assets",
+        operationId = "ScoreAssets",
+        requestBody = @RequestBody(
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ScoringRequest.class))
+        ),
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "A response with the score of the assets",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ScoringResult.class))
+            ),
+        }
+    )
+    ScoringResult scoreAssets(ScoringRequest scoringRequest);
+}

--- a/src/main/java/io/gravitee/scoring/api/model/ScoringRequest.java
+++ b/src/main/java/io/gravitee/scoring/api/model/ScoringRequest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api.model;
+
+import io.gravitee.scoring.api.model.asset.ScoreAsset;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Schema(description = "An object that represents a request to score a list of assets.")
+public record ScoringRequest(List<ScoreAsset> assets) implements Serializable {}

--- a/src/main/java/io/gravitee/scoring/api/model/ScoringResult.java
+++ b/src/main/java/io/gravitee/scoring/api/model/ScoringResult.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api.model;
+
+import io.gravitee.scoring.api.model.diagnostic.AssetDiagnostic;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Schema(description = "An object that represents the result of the scoring operation.")
+public record ScoringResult(
+    List<AssetDiagnostic> assetDiagnostics,
+    @Schema(description = "A boolean that indicates whether the scoring operation was successful.") boolean success,
+    @Schema(description = "A string that contains an error message if the scoring operation failed.") String error
+)
+    implements Serializable {
+    public ScoringResult(List<AssetDiagnostic> assetDiagnostics) {
+        this(assetDiagnostics, true, null);
+    }
+
+    public ScoringResult(String error) {
+        this(List.of(), false, error);
+    }
+}

--- a/src/main/java/io/gravitee/scoring/api/model/asset/AssetType.java
+++ b/src/main/java/io/gravitee/scoring/api/model/asset/AssetType.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api.model.asset;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Schema(description = "An enum representing the type of the asset. The asset type is used to determine which rules to apply to the asset.")
+public enum AssetType {
+    ASYNC_API,
+    OPEN_API,
+    GRAVITEE_API,
+}

--- a/src/main/java/io/gravitee/scoring/api/model/asset/ContentType.java
+++ b/src/main/java/io/gravitee/scoring/api/model/asset/ContentType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api.model.asset;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Define the format of the Asset's content
+ */
+@Schema(description = "An enum representing the content type of the asset. The content type is used to determine how to parse the asset.")
+public enum ContentType {
+    JSON,
+    YAML,
+}

--- a/src/main/java/io/gravitee/scoring/api/model/asset/ScoreAsset.java
+++ b/src/main/java/io/gravitee/scoring/api/model/asset/ScoreAsset.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api.model.asset;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Schema(description = "An object that represents an asset to be scored.")
+public record ScoreAsset(
+    AssetType type,
+    @Schema(description = "A string that contains the file name of the document to be analyzed.") String filename,
+    @Schema(description = "A string that contains the content of the document to be analyzed.") String content,
+    ContentType contentType
+)
+    implements Serializable {}

--- a/src/main/java/io/gravitee/scoring/api/model/diagnostic/AssetDiagnostic.java
+++ b/src/main/java/io/gravitee/scoring/api/model/diagnostic/AssetDiagnostic.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api.model.diagnostic;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
+import java.util.Collection;
+
+@Schema(description = "An object that represents the diagnostics for a specific asset.")
+public record AssetDiagnostic(
+    @Schema(description = "A string that contains the file path of the document that was analyzed.") String asset,
+    @Schema(description = "An array of diagnostic messages that represent the issues found in the asset.")
+    Collection<Diagnostic> diagnostics
+)
+    implements Serializable {}

--- a/src/main/java/io/gravitee/scoring/api/model/diagnostic/Diagnostic.java
+++ b/src/main/java/io/gravitee/scoring/api/model/diagnostic/Diagnostic.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api.model.diagnostic;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
+import java.util.Comparator;
+import lombok.Builder;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Schema(description = "An object that represents a diagnostic message for a specific rule violation.")
+@Builder
+public record Diagnostic(
+    Range range,
+    Severity severity,
+    @Schema(
+        description = "A string that represents the rule code that has been violated or triggered. This code is unique to each rule defined."
+    )
+    String rule,
+    @Schema(
+        description = "A string that contains a human-readable message describing the issue found. This message typically provides information on why the rule was triggered and how to fix the issue."
+    )
+    String message,
+    @Schema(description = "A string that contains the file path of the document that was analyzed.") String asset,
+    @Schema(
+        description = "A string that indicates the location within the analyzed document where the rule was triggered. It shows the \"path\" in the document structure to the issue."
+    )
+    String path
+)
+    implements Serializable, Comparable<Diagnostic> {
+    private static final Comparator<Diagnostic> DIAGNOSTIC_COMPARATOR = Comparator
+        .comparing(Diagnostic::range)
+        .thenComparing(Diagnostic::severity)
+        .thenComparing(Diagnostic::rule)
+        .thenComparing(Diagnostic::message);
+
+    @Override
+    public int compareTo(Diagnostic o) {
+        return DIAGNOSTIC_COMPARATOR.compare(this, o);
+    }
+}

--- a/src/main/java/io/gravitee/scoring/api/model/diagnostic/Position.java
+++ b/src/main/java/io/gravitee/scoring/api/model/diagnostic/Position.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api.model.diagnostic;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
+import java.util.Comparator;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Schema(description = "An object that represents a position within a file. The position is defined by a line and a character.")
+public record Position(
+    @Schema(
+        description = "An integer that represents the character position within the line where the issue starts or ends. The value is zero indexed.",
+        minimum = "0"
+    )
+    int line,
+    @Schema(
+        description = "An integer that represents the character position within the line where the issue starts or ends. The value is zero indexed.",
+        minimum = "0"
+    )
+    int character
+)
+    implements Serializable, Comparable<Position> {
+    private static final Comparator<Position> POSITION_COMPARATOR = Comparator.comparing(Position::line).thenComparing(Position::character);
+
+    @Override
+    public int compareTo(Position other) {
+        return POSITION_COMPARATOR.compare(this, other);
+    }
+}

--- a/src/main/java/io/gravitee/scoring/api/model/diagnostic/Range.java
+++ b/src/main/java/io/gravitee/scoring/api/model/diagnostic/Range.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api.model.diagnostic;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
+import java.util.Comparator;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Schema(description = "An object that describes where in the file the issue was found.")
+public record Range(Position start, Position end) implements Serializable, Comparable<Range> {
+    private static final Comparator<Range> RANGE_COMPARATOR = Comparator.comparing(Range::start).thenComparing(Range::end);
+
+    @Override
+    public int compareTo(Range other) {
+        return RANGE_COMPARATOR.compare(this, other);
+    }
+}

--- a/src/main/java/io/gravitee/scoring/api/model/diagnostic/Severity.java
+++ b/src/main/java/io/gravitee/scoring/api/model/diagnostic/Severity.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api.model.diagnostic;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Schema(
+    description = "An enum representing the severity level of the rule violation. The severity levels usually follow a specific scale defined by providers."
+)
+public enum Severity {
+    ERROR,
+    WARN,
+    INFO,
+    HINT,
+}

--- a/src/main/resources/openapi-configuration.yaml
+++ b/src/main/resources/openapi-configuration.yaml
@@ -1,0 +1,6 @@
+openAPI:
+    info:
+        title: Gravitee.io Scoring Provider API
+        description: |-
+            This is the OpenAPI specification for the Gravitee.io all Scoring Provider.
+        version: "${project.version}"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5164

## Description

[ADR](https://gravitee.slab.com/posts/api-scoring-ri6xqojg)

Implement Interfaces and models common to create Scoring Provider. An OpenAPI spec is also created to allow the creation of Provider using other technologies



<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `0.1.0-initial-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/scoring/gravitee-scoring-api/0.1.0-initial-SNAPSHOT/gravitee-scoring-api-0.1.0-initial-SNAPSHOT.zip)
  <!-- Version placeholder end -->
