### PR TITLE
feat: add custom ruleset record defining a ruleset for a targeted format

### DIFF
--- a/src/main/java/io/gravitee/scoring/api/model/ScoringRequest.java
+++ b/src/main/java/io/gravitee/scoring/api/model/ScoringRequest.java
@@ -16,6 +16,7 @@
 package io.gravitee.scoring.api.model;
 
 import io.gravitee.scoring.api.model.asset.AssetToAnalyze;
+import io.gravitee.scoring.api.model.ruleset.CustomRuleset;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
 import java.util.List;
@@ -25,8 +26,18 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 @Schema(description = "An object that represents a request to score a list of assets.")
-public record ScoringRequest(List<AssetToAnalyze> assets, List<String> customRulesets) implements Serializable {
+public record ScoringRequest(
+    List<AssetToAnalyze> assets,
+    @Deprecated(since = "0.4", forRemoval = true) List<String> customRulesets,
+    List<CustomRuleset> rulesets
+)
+    implements Serializable {
     public ScoringRequest(List<AssetToAnalyze> assets) {
-        this(assets, null);
+        this(assets, null, null);
+    }
+
+    @Deprecated(since = "0.4", forRemoval = true)
+    public ScoringRequest(List<AssetToAnalyze> assets, List<String> customRulesets) {
+        this(assets, customRulesets, null);
     }
 }

--- a/src/main/java/io/gravitee/scoring/api/model/ScoringRequest.java
+++ b/src/main/java/io/gravitee/scoring/api/model/ScoringRequest.java
@@ -16,9 +16,11 @@
 package io.gravitee.scoring.api.model;
 
 import io.gravitee.scoring.api.model.asset.AssetToAnalyze;
+import io.gravitee.scoring.api.model.functions.CustomFunction;
 import io.gravitee.scoring.api.model.ruleset.CustomRuleset;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -29,15 +31,16 @@ import java.util.List;
 public record ScoringRequest(
     List<AssetToAnalyze> assets,
     @Deprecated(since = "0.4", forRemoval = true) List<String> customRulesets,
-    List<CustomRuleset> rulesets
+    Collection<CustomRuleset> rulesets,
+    Collection<CustomFunction> functions
 )
     implements Serializable {
     public ScoringRequest(List<AssetToAnalyze> assets) {
-        this(assets, null, null);
+        this(assets, null, null, null);
     }
 
     @Deprecated(since = "0.4", forRemoval = true)
     public ScoringRequest(List<AssetToAnalyze> assets, List<String> customRulesets) {
-        this(assets, customRulesets, null);
+        this(assets, customRulesets, null, null);
     }
 }

--- a/src/main/java/io/gravitee/scoring/api/model/asset/AssetAnalyzed.java
+++ b/src/main/java/io/gravitee/scoring/api/model/asset/AssetAnalyzed.java
@@ -23,6 +23,11 @@ public record AssetAnalyzed(
     @Schema(description = "Id of the document to be analyzed.") String assetId,
     @Schema(description = "Type of the document to be analyzed.") AssetType type,
     @Schema(description = "A string that contains the file name of the document to be analyzed.") String filename,
-    ContentType contentType
+    ContentType contentType,
+    @Schema(description = "The format of the asset content. Required only to analyze Gravitee API using custom rulesets") Format format
 )
-    implements Serializable {}
+    implements Serializable {
+    public AssetAnalyzed(String assetId, AssetType type, String filename, ContentType contentType) {
+        this(assetId, type, filename, contentType, null);
+    }
+}

--- a/src/main/java/io/gravitee/scoring/api/model/asset/AssetToAnalyze.java
+++ b/src/main/java/io/gravitee/scoring/api/model/asset/AssetToAnalyze.java
@@ -28,6 +28,11 @@ public record AssetToAnalyze(
     @Schema(description = "Type of the document to be analyzed.") AssetType type,
     @Schema(description = "A string that contains the file name of the document to be analyzed.") String filename,
     @Schema(description = "A string that contains the content of the document to be analyzed.") String content,
-    ContentType contentType
+    ContentType contentType,
+    @Schema(description = "The format of the asset content. Required only to analyze Gravitee API using custom rulesets") Format format
 )
-    implements Serializable {}
+    implements Serializable {
+    public AssetToAnalyze(String assetId, AssetType type, String filename, String content, ContentType contentType) {
+        this(assetId, type, filename, content, contentType, null);
+    }
+}

--- a/src/main/java/io/gravitee/scoring/api/model/asset/Format.java
+++ b/src/main/java/io/gravitee/scoring/api/model/asset/Format.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api.model.asset;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+
+@Schema(
+    description = "An enum representing the format of the asset or ruleset. https://docs.stoplight.io/docs/spectral/e5b9616d6d50c-rulesets#formats"
+)
+@RequiredArgsConstructor
+public enum Format {
+    GRAVITEE_PROXY("gravitee_proxy"),
+    GRAVITEE_MESSAGE("gravitee_message"),
+    GRAVITEE_FEDERATED("gravitee_federated");
+
+    @JsonValue
+    final String value;
+}

--- a/src/main/java/io/gravitee/scoring/api/model/functions/CustomFunction.java
+++ b/src/main/java/io/gravitee/scoring/api/model/functions/CustomFunction.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api.model.functions;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public record CustomFunction(String filename, String content) {
+    private static final Pattern FILENAME_PATTERN = Pattern.compile("^[^/]+.js$");
+    public CustomFunction {
+        Objects.requireNonNull(filename, "filename must not be null");
+        Objects.requireNonNull(content, "content must not be null");
+        if (!FILENAME_PATTERN.matcher(filename).find()) {
+            throw new IllegalArgumentException("Invalid filename: " + filename + " should be only the filename without folder");
+        }
+    }
+}

--- a/src/main/java/io/gravitee/scoring/api/model/ruleset/CustomRuleset.java
+++ b/src/main/java/io/gravitee/scoring/api/model/ruleset/CustomRuleset.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.scoring.api.model.ruleset;
+
+import io.gravitee.scoring.api.model.asset.Format;
+import java.io.Serializable;
+import java.util.Objects;
+
+public record CustomRuleset(Format format, String content) implements Serializable {
+    public CustomRuleset {
+        Objects.requireNonNull(content, "content must not be null");
+    }
+
+    public CustomRuleset(String content) {
+        this(null, content);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7532

## Description

Add a CustomRuleset record to define a ruleset targeting a specific format. This will be used to provide a Custom Ruleset to analyze Gravitee API Definitions.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `0.4.0-apim7532-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/scoring/gravitee-scoring-api/0.4.0-apim7532-SNAPSHOT/gravitee-scoring-api-0.4.0-apim7532-SNAPSHOT.zip)
  <!-- Version placeholder end -->
