### PR TITLE
APIM-7712 add errors

### DIFF
--- a/src/main/java/io/gravitee/scoring/api/model/diagnostic/ScoringError.java
+++ b/src/main/java/io/gravitee/scoring/api/model/diagnostic/ScoringError.java
@@ -15,16 +15,13 @@
  */
 package io.gravitee.scoring.api.model.diagnostic;
 
-import io.gravitee.scoring.api.model.asset.AssetAnalyzed;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.io.Serializable;
-import java.util.Collection;
+import java.util.List;
+import lombok.Builder;
 
-@Schema(description = "An object that represents the diagnostics for a specific asset.")
-public record AssetDiagnostic(
-    @Schema(description = "The document that was analyzed.") AssetAnalyzed asset,
-    @Schema(description = "An array of diagnostic messages that represent the issues found in the asset.")
-    Collection<Diagnostic> diagnostics,
-    @Schema(description = "An array of errors.") Collection<ScoringError> errors
-)
-    implements Serializable {}
+@Schema(description = "An object that represents an error in scoring process.")
+@Builder
+public record ScoringError(
+    @Schema(description = "Error code") String code,
+    @Schema(description = "Path in ruleset where error happen.") List<String> path
+) {}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7712

## Description

Add error management
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `0.5.0-apim-7712-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/scoring/gravitee-scoring-api/0.5.0-apim-7712-SNAPSHOT/gravitee-scoring-api-0.5.0-apim-7712-SNAPSHOT.zip)
  <!-- Version placeholder end -->
