### PR TITLE
fix: implement Serializable for ScoringError record

### DIFF
--- a/src/main/java/io/gravitee/scoring/api/model/diagnostic/ScoringError.java
+++ b/src/main/java/io/gravitee/scoring/api/model/diagnostic/ScoringError.java
@@ -16,6 +16,7 @@
 package io.gravitee.scoring.api.model.diagnostic;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
 import java.util.List;
 import lombok.Builder;
 
@@ -24,4 +25,5 @@ import lombok.Builder;
 public record ScoringError(
     @Schema(description = "Error code") String code,
     @Schema(description = "Path in ruleset where error happen.") List<String> path
-) {}
+)
+    implements Serializable {}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7904

## Description

Implements Serializable for ScoringError to fix an issue with handling commands in the cockpit: 
![image](https://github.com/user-attachments/assets/45c62064-9e64-4779-ae4d-5d7dc79c21f2)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `0.5.1-apim-7904-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/scoring/gravitee-scoring-api/0.5.1-apim-7904-SNAPSHOT/gravitee-scoring-api-0.5.1-apim-7904-SNAPSHOT.zip)
  <!-- Version placeholder end -->
